### PR TITLE
additional updates to export and metric fix... mostly housecleaning

### DIFF
--- a/stars/quick_tools/third_party_export-princeton.py
+++ b/stars/quick_tools/third_party_export-princeton.py
@@ -13,7 +13,8 @@ tp = ThirdParty.objects.get(slug="princeton")
 summaries = {}
 institutions = []
 institutions_to_exclude = [
-    8217,  # AASHE Test Campus
+    1082,  # AASHE Test Campus
+    950,  # AASHE Test Campus
     427,  # University of Missouri, Kansas City
     795,  # University of North Carolina, Wilmington
 ]


### PR DESCRIPTION
Just a few little changes based on feedback on the Princeton Review export feedback.

I've also expanded the calculated field fix script to run on both the latest rated submission for each metric institution and their current submission. After review, this has a very limited impact on scoring and none on ratings.

```
York University -- 2.0 (04/20/2016) Score Changed: [55.050000, 54.796020]
HEC Montréal -- 2.1 (06/28/2018) Score Changed: [52.176768, 51.932161]
Concordia University -- 2.0 (05/26/2017) Score Changed: [67.050505, 66.733668]
Selkirk College -- 2.1 (05/28/2019) Score Changed: [49.035897, 48.806122]
```